### PR TITLE
Unificar reglas de puntaje: 2 pts ganador + 1 pt resultado exacto, con penales

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -42,6 +42,8 @@ World Cup matches information.
 | away_team   | TEXT      | Away team name                                 |
 | home_score  | INTEGER   | Home team score (nullable until finished)      |
 | away_score  | INTEGER   | Away team score (nullable until finished)      |
+| home_penalties | INTEGER | Home team penalty shootout score (nullable, only set if regulation ended in a draw) |
+| away_penalties | INTEGER | Away team penalty shootout score (nullable, only set if regulation ended in a draw) |
 | match_date  | TIMESTAMP | When the match is/was played                   |
 | stage       | TEXT      | Tournament stage (e.g., "Group Stage")         |
 | status      | TEXT      | Match status: 'scheduled', 'live', 'finished'  |
@@ -135,21 +137,21 @@ Automatically creates a profile when a new user signs up via Supabase Auth.
 
 ### `calculate_prediction_points()`
 
-Calculates points for all predictions when a match finishes.
+Calculates points for all predictions when a match finishes. Applies to **all matches**
+(group stage and knockout stage).
 
 **Trigger:** After UPDATE on matches when status = 'finished'
 **Scoring System:**
-- **3 points**: Exact score prediction
-- **1 point**: Correct outcome (winner or draw)
-- **0 points**: Incorrect prediction
+- **2 points**: Correct winner (home win, away win, or draw). If the match ended tied
+  in regulation and was decided by a penalty shootout (`home_penalties`/`away_penalties`),
+  the penalty shootout winner is used as the "winner" for this purpose.
+- **+1 point**: Bonus if the exact regulation score (`home_score`/`away_score`) is also correct.
+- **0 points**: Incorrect winner prediction.
 
 **Logic:**
 ```sql
-CASE
-  WHEN exact_score THEN 3
-  WHEN correct_outcome THEN 1
-  ELSE 0
-END
+points = (CASE WHEN predicted_winner = actual_winner THEN 2 ELSE 0 END)
+       + (CASE WHEN exact_score THEN 1 ELSE 0 END)
 ```
 
 ---

--- a/backend/src/controllers/matchesController.js
+++ b/backend/src/controllers/matchesController.js
@@ -114,7 +114,7 @@ export const getGroupsSimple = async (req, res) => {
 export const updateMatchResult = async (req, res) => {
   try {
     const { id } = req.params;
-    const { home_score, away_score } = req.body;
+    const { home_score, away_score, home_penalties, away_penalties } = req.body;
 
     const matchResult = await query('SELECT * FROM matches WHERE id = $1', [id]);
     if (matchResult.rows.length === 0) {
@@ -125,7 +125,7 @@ export const updateMatchResult = async (req, res) => {
     if (home_score === null && away_score === null) {
       const updated = await query(
         `UPDATE matches
-         SET home_score = NULL, away_score = NULL, status = 'scheduled', updated_at = NOW()
+         SET home_score = NULL, away_score = NULL, home_penalties = NULL, away_penalties = NULL, status = 'scheduled', updated_at = NOW()
          WHERE id = $1
          RETURNING *`,
         [id]
@@ -141,13 +141,31 @@ export const updateMatchResult = async (req, res) => {
       return res.status(400).json({ error: 'home_score y away_score deben ser números enteros >= 0' });
     }
 
+    // Penales: solo tienen sentido si el partido terminó empatado y deben tener un ganador
+    let penaltiesHome = null;
+    let penaltiesAway = null;
+    if (home_penalties !== undefined && home_penalties !== null && away_penalties !== undefined && away_penalties !== null) {
+      if (home_score !== away_score) {
+        return res.status(400).json({ error: 'Los penales solo aplican si el partido terminó empatado' });
+      }
+      if (
+        !Number.isInteger(home_penalties) || !Number.isInteger(away_penalties) ||
+        home_penalties < 0 || away_penalties < 0 || home_penalties === away_penalties
+      ) {
+        return res.status(400).json({ error: 'home_penalties y away_penalties deben ser números enteros >= 0 y distintos entre sí' });
+      }
+      penaltiesHome = home_penalties;
+      penaltiesAway = away_penalties;
+    }
+
     // Guardar resultado y marcar como finalizado: el trigger calcula los puntos
+    // (2 pts por acertar el ganador —el de los penales si hubo definición— + 1 pt extra por resultado exacto)
     const updated = await query(
       `UPDATE matches
-       SET home_score = $1, away_score = $2, status = 'finished', updated_at = NOW()
-       WHERE id = $3
+       SET home_score = $1, away_score = $2, home_penalties = $3, away_penalties = $4, status = 'finished', updated_at = NOW()
+       WHERE id = $5
        RETURNING *`,
-      [home_score, away_score, id]
+      [home_score, away_score, penaltiesHome, penaltiesAway, id]
     );
 
     res.json({ match: updated.rows[0] });

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -27,13 +27,21 @@ function AdminMatchRow({
 }) {
   const [homeScore, setHomeScore] = useState(match.home_score ?? 0)
   const [awayScore, setAwayScore] = useState(match.away_score ?? 0)
+  const [homePenalties, setHomePenalties] = useState<number | ''>(match.home_penalties ?? '')
+  const [awayPenalties, setAwayPenalties] = useState<number | ''>(match.away_penalties ?? '')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState(false)
 
   const hasResult = match.home_score !== null && match.away_score !== null
+  const isDraw = homeScore === awayScore
+  const showPenalties = isDraw && !isGroupStage(match.stage)
 
-  const updateResult = async (homeValue: number | null, awayValue: number | null) => {
+  const updateResult = async (
+    homeValue: number | null,
+    awayValue: number | null,
+    penalties?: { home: number; away: number } | null
+  ) => {
     setLoading(true)
     setError(null)
     setSuccess(false)
@@ -46,7 +54,12 @@ function AdminMatchRow({
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify({ home_score: homeValue, away_score: awayValue }),
+        body: JSON.stringify({
+          home_score: homeValue,
+          away_score: awayValue,
+          home_penalties: penalties ? penalties.home : null,
+          away_penalties: penalties ? penalties.away : null,
+        }),
       })
 
       const data = await response.json()
@@ -65,6 +78,25 @@ function AdminMatchRow({
     }
   }
 
+  const handleSaveResult = () => {
+    if (!showPenalties) {
+      updateResult(homeScore, awayScore, null)
+      return
+    }
+
+    if (homePenalties === '' || awayPenalties === '') {
+      setError('Si el partido termina en penales, ingresá el resultado de la definición')
+      return
+    }
+
+    if (homePenalties === awayPenalties) {
+      setError('Los penales no pueden terminar empatados')
+      return
+    }
+
+    updateResult(homeScore, awayScore, { home: homePenalties, away: awayPenalties })
+  }
+
   return (
     <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
       <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
@@ -73,22 +105,44 @@ function AdminMatchRow({
           <p className="text-sm font-semibold text-slate-900">{match.home_team}</p>
         </div>
 
-        <div className="flex items-center justify-center gap-3">
-          <input
-            type="number"
-            min="0"
-            value={homeScore}
-            onChange={(e) => setHomeScore(parseInt(e.target.value) || 0)}
-            className="h-10 w-14 rounded-lg border border-slate-200 text-center text-sm"
-          />
-          <span className="text-xs font-semibold text-slate-400">vs</span>
-          <input
-            type="number"
-            min="0"
-            value={awayScore}
-            onChange={(e) => setAwayScore(parseInt(e.target.value) || 0)}
-            className="h-10 w-14 rounded-lg border border-slate-200 text-center text-sm"
-          />
+        <div className="flex flex-col items-center gap-2">
+          <div className="flex items-center justify-center gap-3">
+            <input
+              type="number"
+              min="0"
+              value={homeScore}
+              onChange={(e) => setHomeScore(parseInt(e.target.value) || 0)}
+              className="h-10 w-14 rounded-lg border border-slate-200 text-center text-sm"
+            />
+            <span className="text-xs font-semibold text-slate-400">vs</span>
+            <input
+              type="number"
+              min="0"
+              value={awayScore}
+              onChange={(e) => setAwayScore(parseInt(e.target.value) || 0)}
+              className="h-10 w-14 rounded-lg border border-slate-200 text-center text-sm"
+            />
+          </div>
+          {showPenalties && (
+            <div className="flex items-center justify-center gap-2">
+              <span className="text-[10px] font-semibold text-slate-400">Penales</span>
+              <input
+                type="number"
+                min="0"
+                value={homePenalties}
+                onChange={(e) => setHomePenalties(e.target.value === '' ? '' : parseInt(e.target.value) || 0)}
+                className="h-8 w-12 rounded-lg border border-slate-200 text-center text-xs"
+              />
+              <span className="text-xs font-semibold text-slate-400">-</span>
+              <input
+                type="number"
+                min="0"
+                value={awayPenalties}
+                onChange={(e) => setAwayPenalties(e.target.value === '' ? '' : parseInt(e.target.value) || 0)}
+                className="h-8 w-12 rounded-lg border border-slate-200 text-center text-xs"
+              />
+            </div>
+          )}
         </div>
 
         <div className="flex flex-1 items-center justify-end gap-3">
@@ -98,7 +152,14 @@ function AdminMatchRow({
       </div>
 
       <div className="mt-4 flex flex-col gap-3 border-t border-slate-100 pt-3 text-xs text-slate-500 md:flex-row md:items-center md:justify-between">
-        <span>{formatDate(match.match_date)}</span>
+        <span>
+          {formatDate(match.match_date)}
+          {match.status === 'finished' && match.home_penalties != null && match.away_penalties != null && (
+            <span className="ml-2 font-semibold text-slate-600">
+              · Penales {match.home_penalties}-{match.away_penalties}
+            </span>
+          )}
+        </span>
         <div className="flex items-center gap-3">
           <span
             className={`rounded-full px-3 py-1 font-semibold ${
@@ -110,7 +171,7 @@ function AdminMatchRow({
           <button
             type="button"
             disabled={loading}
-            onClick={() => updateResult(homeScore, awayScore)}
+            onClick={handleSaveResult}
             className="rounded-full bg-sky-600 px-4 py-1 text-xs font-semibold text-white transition hover:bg-sky-700 disabled:opacity-50"
           >
             {loading ? 'Guardando...' : 'Guardar resultado'}
@@ -119,7 +180,7 @@ function AdminMatchRow({
             <button
               type="button"
               disabled={loading}
-              onClick={() => updateResult(null, null)}
+              onClick={() => updateResult(null, null, null)}
               className="rounded-full bg-slate-200 px-4 py-1 text-xs font-semibold text-slate-700 transition hover:bg-slate-300 disabled:opacity-50"
             >
               Borrar resultado

--- a/frontend/app/dashboard/rules/page.tsx
+++ b/frontend/app/dashboard/rules/page.tsx
@@ -6,14 +6,14 @@ import DashboardNav from '@/components/ui/DashboardNav'
 
 const groupScoring = [
   {
-    label: 'Acertar resultado',
+    label: 'Acertar el ganador',
     points: '2 puntos',
-    detail: 'Por predecir correctamente victoria local, visitante o empate.',
+    detail: 'Por predecir correctamente quién gana el partido (o el empate). Si el partido se define por penales, cuenta como "ganador" el equipo que se queda con la serie de penales.',
   },
   {
     label: 'Bonus por resultado exacto',
     points: '+1 punto',
-    detail: 'Puntos adicionales si aciertas el marcador exacto (ej: 2-1).',
+    detail: 'Punto adicional si además aciertas el marcador exacto del partido (ej: 2-1).',
   },
 ]
 
@@ -39,6 +39,10 @@ const maxPoints = [
 ]
 
 const importantRules = [
+  {
+    title: 'Puntaje por Partido (Aplica a Todos los Partidos)',
+    text: 'En cualquier partido del Mundial, ya sea de fase de grupos o eliminatorias: 2 puntos por acertar el ganador, +1 punto extra si además acertás el resultado exacto. Si el partido termina empatado y se define por penales, el ganador de la definición por penales es el "ganador" del partido a los efectos de estos puntos.',
+  },
   {
     title: 'Plazos de Pronósticos',
     text: 'Las predicciones de cada partido se cierran 2 horas antes de su inicio. Pasado ese momento no se aceptan cambios.',

--- a/frontend/app/rules/page.tsx
+++ b/frontend/app/rules/page.tsx
@@ -6,14 +6,14 @@ import DashboardNav from '@/components/ui/DashboardNav'
 
 const groupScoring = [
   {
-    label: 'Acertar resultado',
+    label: 'Acertar el ganador',
     points: '2 puntos',
-    detail: 'Por predecir correctamente victoria local, visitante o empate.',
+    detail: 'Por predecir correctamente quién gana el partido (o el empate). Si el partido se define por penales, cuenta como "ganador" el equipo que se queda con la serie de penales.',
   },
   {
     label: 'Bonus por resultado exacto',
     points: '+1 punto',
-    detail: 'Puntos adicionales si aciertas el marcador exacto (ej: 2-1).',
+    detail: 'Punto adicional si además aciertas el marcador exacto del partido (ej: 2-1).',
   },
 ]
 
@@ -39,6 +39,10 @@ const maxPoints = [
 ]
 
 const importantRules = [
+  {
+    title: 'Puntaje por Partido (Aplica a Todos los Partidos)',
+    text: 'En cualquier partido del Mundial, ya sea de fase de grupos o eliminatorias: 2 puntos por acertar el ganador, +1 punto extra si además acertás el resultado exacto. Si el partido termina empatado y se define por penales, el ganador de la definición por penales es el "ganador" del partido a los efectos de estos puntos.',
+  },
   {
     title: 'Plazos de Pronósticos',
     text: 'Las predicciones de cada partido se cierran 2 horas antes de su inicio. Pasado ese momento no se aceptan cambios.',

--- a/frontend/components/matches/ResultsTabs.tsx
+++ b/frontend/components/matches/ResultsTabs.tsx
@@ -14,6 +14,8 @@ export interface Match {
   away_team: string
   home_score: number | null
   away_score: number | null
+  home_penalties?: number | null
+  away_penalties?: number | null
   match_date: string
   stage: string
   status: 'scheduled' | 'live' | 'finished'
@@ -664,7 +666,14 @@ function ResultRow({
       </div>
 
       <div className="mt-4 flex flex-col gap-3 border-t border-slate-100 pt-3 text-xs text-slate-500 md:flex-row md:items-center md:justify-between">
-        <span>{formatDate(match.match_date)}</span>
+        <span>
+          {formatDate(match.match_date)}
+          {isFinished && match.home_penalties != null && match.away_penalties != null && (
+            <span className="ml-2 font-semibold text-slate-600">
+              · Penales {match.home_penalties}-{match.away_penalties}
+            </span>
+          )}
+        </span>
         <div className="flex items-center gap-3">
           <span className={`rounded-full px-3 py-1 font-semibold ${statusStyles(match.status, locked, allowPredict)}`}>
             {statusLabel(match.status, locked, allowPredict)}

--- a/supabase/migrations/20260610_match_scoring_rules.sql
+++ b/supabase/migrations/20260610_match_scoring_rules.sql
@@ -1,0 +1,79 @@
+-- Reglas de puntaje unificadas para todos los partidos (grupos y eliminatorias):
+--   - 2 puntos por acertar el ganador del partido.
+--   - +1 punto extra si además acertás el resultado exacto (tiempo reglamentario).
+--   - Si el partido termina empatado y se define por penales, el ganador de la
+--     definición por penales es el "ganador" del partido a estos efectos.
+
+-- 1) Columnas para registrar el resultado de la definición por penales (si aplica)
+ALTER TABLE matches
+  ADD COLUMN IF NOT EXISTS home_penalties INTEGER,
+  ADD COLUMN IF NOT EXISTS away_penalties INTEGER;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'matches_penalties_valid'
+  ) THEN
+    ALTER TABLE matches
+      ADD CONSTRAINT matches_penalties_valid CHECK (
+        (home_penalties IS NULL AND away_penalties IS NULL)
+        OR (
+          home_penalties >= 0 AND away_penalties >= 0
+          AND home_penalties <> away_penalties
+        )
+      );
+  END IF;
+END $$;
+
+-- 2) Recalcular puntos: 2 por ganador (incluye definición por penales) + 1 por resultado exacto
+CREATE OR REPLACE FUNCTION calculate_prediction_points()
+RETURNS TRIGGER AS $$
+DECLARE
+  pred RECORD;
+  actual_winner TEXT;
+  predicted_winner TEXT;
+BEGIN
+  IF NEW.status = 'finished' AND NEW.home_score IS NOT NULL AND NEW.away_score IS NOT NULL THEN
+    -- Ganador real: resultado del partido, o definición por penales si terminó empatado
+    IF NEW.home_score > NEW.away_score THEN
+      actual_winner := 'home';
+    ELSIF NEW.home_score < NEW.away_score THEN
+      actual_winner := 'away';
+    ELSIF NEW.home_penalties IS NOT NULL AND NEW.away_penalties IS NOT NULL
+          AND NEW.home_penalties <> NEW.away_penalties THEN
+      actual_winner := CASE WHEN NEW.home_penalties > NEW.away_penalties THEN 'home' ELSE 'away' END;
+    ELSE
+      actual_winner := 'draw';
+    END IF;
+
+    FOR pred IN
+      SELECT * FROM predictions WHERE match_id = NEW.id
+    LOOP
+      predicted_winner := CASE
+        WHEN pred.predicted_home_score > pred.predicted_away_score THEN 'home'
+        WHEN pred.predicted_home_score < pred.predicted_away_score THEN 'away'
+        ELSE 'draw'
+      END;
+
+      UPDATE predictions
+      SET points =
+        -- 2 puntos por acertar el ganador (o el ganador de la definición por penales)
+        (CASE WHEN predicted_winner = actual_winner THEN 2 ELSE 0 END)
+        -- +1 punto extra por acertar el resultado exacto del partido
+        + (CASE
+             WHEN pred.predicted_home_score = NEW.home_score
+              AND pred.predicted_away_score = NEW.away_score THEN 1
+             ELSE 0
+           END),
+      updated_at = NOW()
+      WHERE id = pred.id;
+    END LOOP;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3) Recalcular puntos de partidos ya finalizados con la nueva fórmula
+UPDATE matches
+SET updated_at = NOW()
+WHERE status = 'finished' AND home_score IS NOT NULL AND away_score IS NOT NULL;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -30,11 +30,20 @@ CREATE TABLE IF NOT EXISTS matches (
   away_team TEXT NOT NULL,
   home_score INTEGER,
   away_score INTEGER,
+  home_penalties INTEGER,
+  away_penalties INTEGER,
   match_date TIMESTAMP WITH TIME ZONE NOT NULL,
   stage TEXT NOT NULL,
   status TEXT DEFAULT 'scheduled' CHECK (status IN ('scheduled', 'live', 'finished')),
   created_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc', NOW()) NOT NULL,
-  updated_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc', NOW()) NOT NULL
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc', NOW()) NOT NULL,
+  CONSTRAINT matches_penalties_valid CHECK (
+    (home_penalties IS NULL AND away_penalties IS NULL)
+    OR (
+      home_penalties >= 0 AND away_penalties >= 0
+      AND home_penalties <> away_penalties
+    )
+  )
 );
 
 -- Create predictions table
@@ -143,34 +152,52 @@ CREATE TRIGGER on_auth_user_created
   FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
 
 -- Function to calculate points for predictions
+-- Reglas: 2 puntos por acertar el ganador (si el partido termina empatado y se
+-- define por penales, el ganador de la definición por penales es el ganador
+-- a estos efectos) + 1 punto extra si además se acierta el resultado exacto.
 CREATE OR REPLACE FUNCTION calculate_prediction_points()
 RETURNS TRIGGER AS $$
 DECLARE
   pred RECORD;
+  actual_winner TEXT;
+  predicted_winner TEXT;
 BEGIN
   -- Only calculate when match is finished and has scores
   IF NEW.status = 'finished' AND NEW.home_score IS NOT NULL AND NEW.away_score IS NOT NULL THEN
+    IF NEW.home_score > NEW.away_score THEN
+      actual_winner := 'home';
+    ELSIF NEW.home_score < NEW.away_score THEN
+      actual_winner := 'away';
+    ELSIF NEW.home_penalties IS NOT NULL AND NEW.away_penalties IS NOT NULL
+          AND NEW.home_penalties <> NEW.away_penalties THEN
+      actual_winner := CASE WHEN NEW.home_penalties > NEW.away_penalties THEN 'home' ELSE 'away' END;
+    ELSE
+      actual_winner := 'draw';
+    END IF;
+
     -- Update all predictions for this match
-    FOR pred IN 
+    FOR pred IN
       SELECT * FROM predictions WHERE match_id = NEW.id
     LOOP
+      predicted_winner := CASE
+        WHEN pred.predicted_home_score > pred.predicted_away_score THEN 'home'
+        WHEN pred.predicted_home_score < pred.predicted_away_score THEN 'away'
+        ELSE 'draw'
+      END;
+
       UPDATE predictions
-      SET points = CASE
-        -- Exact score: 3 points
-        WHEN pred.predicted_home_score = NEW.home_score 
-         AND pred.predicted_away_score = NEW.away_score THEN 3
-        -- Correct winner/draw: 1 point
-        WHEN (pred.predicted_home_score > pred.predicted_away_score AND NEW.home_score > NEW.away_score)
-          OR (pred.predicted_home_score < pred.predicted_away_score AND NEW.home_score < NEW.away_score)
-          OR (pred.predicted_home_score = pred.predicted_away_score AND NEW.home_score = NEW.away_score) THEN 1
-        -- Incorrect: 0 points
-        ELSE 0
-      END,
+      SET points =
+        (CASE WHEN predicted_winner = actual_winner THEN 2 ELSE 0 END)
+        + (CASE
+             WHEN pred.predicted_home_score = NEW.home_score
+              AND pred.predicted_away_score = NEW.away_score THEN 1
+             ELSE 0
+           END),
       updated_at = NOW()
       WHERE id = pred.id;
     END LOOP;
   END IF;
-  
+
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
Corrige el trigger de puntaje (1pt ganador / 3pt exacto) para que coincida
con las reglas documentadas: 2 puntos por acertar el ganador del partido y
+1 punto extra si además se acierta el resultado exacto. Aplica a todos los
partidos (grupos y eliminatorias).

Agrega soporte para definiciones por penales: nuevas columnas
home_penalties/away_penalties en matches, usadas como ganador del partido
cuando termina empatado. El admin puede cargar el resultado de los penales
desde el panel cuando un partido de eliminatorias termina en empate.

Aclara las páginas de reglas en el frontend con esta lógica unificada.