### PR TITLE
Unify knockout scoring with group stage and add TBD knockout matches

### DIFF
--- a/frontend/app/dashboard/rules/page.tsx
+++ b/frontend/app/dashboard/rules/page.tsx
@@ -23,25 +23,16 @@ const scoringExamples = [
   'Real: México 2-0 | Tu pronóstico: Empate 1-1 → 0 pts ✗',
 ]
 
-const knockoutScoring = [
-  { label: 'Dieciseisavos de Final (16 equipos)', points: '2 pts por equipo' },
-  { label: 'Octavos de Final (8 equipos)', points: '4 pts por equipo' },
-  { label: 'Cuartos de Final (4 equipos)', points: '6 pts por equipo' },
-  { label: 'Semifinales (2 equipos)', points: '8 pts por equipo' },
-  { label: 'Finalistas (2 equipos)', points: '10 pts por equipo' },
-  { label: 'Campeón del Mundial', points: '+10 pts bonus adicional' },
-]
-
 const maxPoints = [
-  { label: 'Fase de Grupos', points: '216', detail: '61.7% del total' },
-  { label: 'Fase Eliminatoria', points: '134', detail: '38.3% del total' },
-  { label: 'Puntos Máximos Totales', points: '350', detail: 'Total posible' },
+  { label: 'Fase de Grupos', points: '216', detail: '69.2% del total' },
+  { label: 'Fase Eliminatoria', points: '96', detail: '30.8% del total' },
+  { label: 'Puntos Máximos Totales', points: '312', detail: 'Total posible' },
 ]
 
 const importantRules = [
   {
     title: 'Puntaje por Partido (Aplica a Todos los Partidos)',
-    text: 'En cualquier partido del Mundial, ya sea de fase de grupos o eliminatorias: 2 puntos por acertar el ganador, +1 punto extra si además acertás el resultado exacto. Si el partido termina empatado y se define por penales, el ganador de la definición por penales es el "ganador" del partido a los efectos de estos puntos.',
+    text: 'En cualquier partido del Mundial, ya sea de fase de grupos o eliminatorias: 2 puntos por acertar el ganador, +1 punto extra si además acertás el resultado exacto. Si el partido termina empatado y se define por penales, el ganador de la definición por penales es el "ganador" del partido a los efectos de estos puntos, y el resultado exacto que vale el punto extra es el marcador del tiempo reglamentario (el empate, ej: 1-1), no el resultado de los penales.',
   },
   {
     title: 'Plazos de Pronósticos',
@@ -52,12 +43,12 @@ const importantRules = [
     text: 'Si no completas pronósticos para algún partido: 0 puntos para esos partidos. No hay penalización adicional.',
   },
   {
-    title: 'Fase Eliminatoria',
-    text: 'Solo importa qué equipo avanza, no el resultado del partido. Si un equipo gana en penales, cuenta como clasificado.',
+    title: 'Partidos "Por Definir"',
+    text: 'Los cruces de la fase eliminatoria se completan a medida que se conocen los clasificados de cada llave. Mientras el cruce figure como "Por definir" todavía no se puede cargar un pronóstico para ese partido.',
   },
   {
-    title: 'Partido Tercer Puesto',
-    text: 'El partido por el tercer puesto NO otorga puntos en este sistema.',
+    title: 'Partido por el Tercer Puesto',
+    text: 'Suma puntos igual que cualquier otro partido: 2 puntos por acertar el ganador, +1 por el resultado exacto.',
   },
 ]
 
@@ -66,7 +57,7 @@ const tips = [
   'Usa "Llenar Aleatorio" para completar rápidamente un grupo y luego ajusta tus predicciones.',
   'Revisa el Ranking regularmente para ver cómo te compara con otros participantes.',
   'Completa tus predicciones temprano para evitar perder partidos.',
-  'No descuides las eliminatorias - representan el 38% de los puntos totales.',
+  'No descuides las eliminatorias - representan el 30.8% de los puntos totales.',
 ]
 
 export default function RulesPage() {
@@ -193,30 +184,42 @@ export default function RulesPage() {
 
           <div className="rounded-2xl border border-sky-200 bg-white p-6 shadow-sm">
             <h3 className="text-lg font-semibold text-slate-900">
-              🏆 Fase Eliminatoria
+              🏆 Fase Eliminatoria (32 partidos)
             </h3>
             <p className="mt-2 text-sm text-slate-600">
-              En las eliminatorias, los puntos se otorgan por acertar qué equipos clasifican a la siguiente ronda (no
-              importa el resultado específico del partido).
+              Mismo sistema de puntos que la fase de grupos: 2 puntos por acertar el ganador, +1 punto extra por el
+              resultado exacto.
             </p>
             <div className="mt-4 grid gap-3">
-              {knockoutScoring.map((row) => (
-                <div key={row.label} className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-sky-100 bg-sky-50 px-3 py-2">
-                  <span className="text-sm text-slate-800">
-                    {row.label}
-                  </span>
-                  <span className="rounded-full bg-sky-600 px-3 py-1 text-[11px] font-semibold text-white">
-                    {row.points}
-                  </span>
+              {groupScoring.map((row) => (
+                <div key={row.label} className="rounded-lg border border-sky-100 bg-sky-50 px-3 py-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-sm font-semibold text-slate-900">
+                      {row.label}
+                    </p>
+                    <span className="rounded-full bg-sky-600 px-3 py-1 text-[11px] font-semibold text-white">
+                      {row.points}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-xs text-slate-600">
+                    {row.detail}
+                  </p>
                 </div>
               ))}
             </div>
             <div className="mt-4 rounded-lg border border-sky-200 bg-sky-50 px-4 py-3">
               <p className="text-xs text-slate-600">
-                💡 Nota: Si aciertas al campeón, obtienes 10 pts por finalista + 10 pts por campeón = 20 puntos
-                totales por ese equipo.
+                ⚽ Si el partido se define por penales: el ganador de la serie de penales cuenta como "ganador" del
+                partido (2 pts), y el resultado exacto que vale el punto extra es el marcador del tiempo
+                reglamentario, es decir, el empate (ej: 1-1), no el resultado de los penales.
               </p>
             </div>
+            <p className="mt-3 text-xs text-slate-700">
+              Máximo por partido: 3 puntos
+            </p>
+            <p className="text-xs text-slate-700">
+              Total posible en fase eliminatoria: 96 puntos
+            </p>
           </div>
         </div>
 

--- a/frontend/app/predictions/page.tsx
+++ b/frontend/app/predictions/page.tsx
@@ -41,7 +41,7 @@ export default function PredictionsPage() {
       setIsAdmin(!!u.is_admin)
     }
 
-    // Todos los partidos de fase de grupos
+    // Todos los partidos: fase de grupos y fase eliminatoria
     fetch(`${API_URL}/api/matches`, {
       headers: { Authorization: `Bearer ${token}` },
     })
@@ -52,12 +52,7 @@ export default function PredictionsPage() {
           return
         }
         const data = await res.json()
-        const groupMatches = (data.matches || []).filter((match: Match) => {
-          const stage = `${match.stage || ''}`.toLowerCase()
-          const isGroup = stage.includes('group') || stage.includes('grupo')
-          return isGroup
-        })
-        setMatches(groupMatches)
+        setMatches(data.matches || [])
       })
       .catch(console.error)
       .finally(() => setLoading(false))
@@ -80,7 +75,7 @@ export default function PredictionsPage() {
           userId={userId}
           showSecondaryTabs={false}
           title="Tus Predicciones"
-          description="Completá los partidos de la fase de grupos y guardá tus pronósticos. Las predicciones cierran 2 horas antes del inicio de cada partido."
+          description="Completá tus pronósticos para la fase de grupos y la fase eliminatoria. Las predicciones cierran 2 horas antes del inicio de cada partido. Los cruces de eliminatorias 'Por definir' se habilitan cuando se conocen los equipos."
         />
       </div>
     </div>

--- a/frontend/app/rules/page.tsx
+++ b/frontend/app/rules/page.tsx
@@ -23,25 +23,16 @@ const scoringExamples = [
   'Real: México 2-0 | Tu pronóstico: Empate 1-1 → 0 pts ✗',
 ]
 
-const knockoutScoring = [
-  { label: 'Dieciseisavos de Final (16 equipos)', points: '2 pts por equipo' },
-  { label: 'Octavos de Final (8 equipos)', points: '4 pts por equipo' },
-  { label: 'Cuartos de Final (4 equipos)', points: '6 pts por equipo' },
-  { label: 'Semifinales (2 equipos)', points: '8 pts por equipo' },
-  { label: 'Finalistas (2 equipos)', points: '10 pts por equipo' },
-  { label: 'Campeón del Mundial', points: '+10 pts bonus adicional' },
-]
-
 const maxPoints = [
-  { label: 'Fase de Grupos', points: '216', detail: '61.7% del total' },
-  { label: 'Fase Eliminatoria', points: '134', detail: '38.3% del total' },
-  { label: 'Puntos Máximos Totales', points: '350', detail: 'Total posible' },
+  { label: 'Fase de Grupos', points: '216', detail: '69.2% del total' },
+  { label: 'Fase Eliminatoria', points: '96', detail: '30.8% del total' },
+  { label: 'Puntos Máximos Totales', points: '312', detail: 'Total posible' },
 ]
 
 const importantRules = [
   {
     title: 'Puntaje por Partido (Aplica a Todos los Partidos)',
-    text: 'En cualquier partido del Mundial, ya sea de fase de grupos o eliminatorias: 2 puntos por acertar el ganador, +1 punto extra si además acertás el resultado exacto. Si el partido termina empatado y se define por penales, el ganador de la definición por penales es el "ganador" del partido a los efectos de estos puntos.',
+    text: 'En cualquier partido del Mundial, ya sea de fase de grupos o eliminatorias: 2 puntos por acertar el ganador, +1 punto extra si además acertás el resultado exacto. Si el partido termina empatado y se define por penales, el ganador de la definición por penales es el "ganador" del partido a los efectos de estos puntos, y el resultado exacto que vale el punto extra es el marcador del tiempo reglamentario (el empate, ej: 1-1), no el resultado de los penales.',
   },
   {
     title: 'Plazos de Pronósticos',
@@ -52,12 +43,12 @@ const importantRules = [
     text: 'Si no completas pronósticos para algún partido: 0 puntos para esos partidos. No hay penalización adicional.',
   },
   {
-    title: 'Fase Eliminatoria',
-    text: 'Solo importa qué equipo avanza, no el resultado del partido. Si un equipo gana en penales, cuenta como clasificado.',
+    title: 'Partidos "Por Definir"',
+    text: 'Los cruces de la fase eliminatoria se completan a medida que se conocen los clasificados de cada llave. Mientras el cruce figure como "Por definir" todavía no se puede cargar un pronóstico para ese partido.',
   },
   {
-    title: 'Partido Tercer Puesto',
-    text: 'El partido por el tercer puesto NO otorga puntos en este sistema.',
+    title: 'Partido por el Tercer Puesto',
+    text: 'Suma puntos igual que cualquier otro partido: 2 puntos por acertar el ganador, +1 por el resultado exacto.',
   },
 ]
 
@@ -66,7 +57,7 @@ const tips = [
   'Usa "Llenar Aleatorio" para completar rápidamente un grupo y luego ajusta tus predicciones.',
   'Revisa el Ranking regularmente para ver cómo te compara con otros participantes.',
   'Completa tus predicciones temprano para evitar perder partidos.',
-  'No descuides las eliminatorias - representan el 38% de los puntos totales.',
+  'No descuides las eliminatorias - representan el 30.8% de los puntos totales.',
 ]
 
 export default function RulesPage() {
@@ -188,30 +179,42 @@ export default function RulesPage() {
 
           <div className="rounded-2xl border border-sky-200 bg-white p-6 shadow-sm">
             <h3 className="text-lg font-semibold text-slate-900">
-              🏆 Fase Eliminatoria
+              🏆 Fase Eliminatoria (32 partidos)
             </h3>
             <p className="mt-2 text-sm text-slate-600">
-              En las eliminatorias, los puntos se otorgan por acertar qué equipos clasifican a la siguiente ronda (no
-              importa el resultado específico del partido).
+              Mismo sistema de puntos que la fase de grupos: 2 puntos por acertar el ganador, +1 punto extra por el
+              resultado exacto.
             </p>
             <div className="mt-4 grid gap-3">
-              {knockoutScoring.map((row) => (
-                <div key={row.label} className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-sky-100 bg-sky-50 px-3 py-2">
-                  <span className="text-sm text-slate-800">
-                    {row.label}
-                  </span>
-                  <span className="rounded-full bg-sky-600 px-3 py-1 text-[11px] font-semibold text-white">
-                    {row.points}
-                  </span>
+              {groupScoring.map((row) => (
+                <div key={row.label} className="rounded-lg border border-sky-100 bg-sky-50 px-3 py-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-sm font-semibold text-slate-900">
+                      {row.label}
+                    </p>
+                    <span className="rounded-full bg-sky-600 px-3 py-1 text-[11px] font-semibold text-white">
+                      {row.points}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-xs text-slate-600">
+                    {row.detail}
+                  </p>
                 </div>
               ))}
             </div>
             <div className="mt-4 rounded-lg border border-sky-200 bg-sky-50 px-4 py-3">
               <p className="text-xs text-slate-600">
-                💡 Nota: Si aciertas al campeón, obtienes 10 pts por finalista + 10 pts por campeón = 20 puntos
-                totales por ese equipo.
+                ⚽ Si el partido se define por penales: el ganador de la serie de penales cuenta como "ganador" del
+                partido (2 pts), y el resultado exacto que vale el punto extra es el marcador del tiempo
+                reglamentario, es decir, el empate (ej: 1-1), no el resultado de los penales.
               </p>
             </div>
+            <p className="mt-3 text-xs text-slate-700">
+              Máximo por partido: 3 puntos
+            </p>
+            <p className="text-xs text-slate-700">
+              Total posible en fase eliminatoria: 96 puntos
+            </p>
           </div>
         </div>
 

--- a/frontend/components/matches/ResultsTabs.tsx
+++ b/frontend/components/matches/ResultsTabs.tsx
@@ -463,6 +463,10 @@ export function isGroupStage(stage: string) {
   return value.includes('group') || value.includes('grupo')
 }
 
+export function isTBD(match: Match) {
+  return match.home_team === 'Por definir' || match.away_team === 'Por definir'
+}
+
 export function formatDate(value: string) {
   return new Date(value)
     .toLocaleString('es-AR', {
@@ -477,14 +481,16 @@ export function formatDate(value: string) {
     .replace(',', '')
 }
 
-function statusLabel(status: Match['status'], locked: boolean, allowPredict: boolean) {
+function statusLabel(status: Match['status'], locked: boolean, allowPredict: boolean, tbd: boolean) {
+  if (tbd) return 'Por definir'
   if (status === 'finished') return allowPredict ? 'Finalizado' : 'Resultado'
   if (status === 'live') return 'En vivo'
   if (allowPredict && locked) return 'Cerrado'
   return 'Por jugar'
 }
 
-function statusStyles(status: Match['status'], locked: boolean, allowPredict: boolean) {
+function statusStyles(status: Match['status'], locked: boolean, allowPredict: boolean, tbd: boolean) {
+  if (tbd) return 'bg-slate-100 text-slate-500'
   if (status === 'finished') return 'bg-slate-100 text-slate-700'
   if (status === 'live') return 'bg-rose-100 text-rose-700'
   if (allowPredict && locked) return 'bg-amber-100 text-amber-700'
@@ -517,8 +523,9 @@ function ResultRow({
   }, [prediction])
 
   const isFinished = match.status === 'finished'
+  const tbd = isTBD(match)
   const locked = Date.now() >= new Date(match.match_date).getTime() - 2 * 60 * 60 * 1000
-  const canPredict = allowPredict && !isFinished && !locked
+  const canPredict = allowPredict && !isFinished && !locked && !tbd
   const isSaved = !!prediction
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -604,7 +611,11 @@ function ResultRow({
         </div>
 
         <div className="flex items-center justify-center gap-3">
-          {canPredict ? (
+          {tbd ? (
+            <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-500">
+              Por definir
+            </span>
+          ) : canPredict ? (
             isSaved ? (
               <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
                 <span className="h-9 w-10 rounded-lg border border-slate-200 bg-slate-50 text-center leading-9">
@@ -675,10 +686,10 @@ function ResultRow({
           )}
         </span>
         <div className="flex items-center gap-3">
-          <span className={`rounded-full px-3 py-1 font-semibold ${statusStyles(match.status, locked, allowPredict)}`}>
-            {statusLabel(match.status, locked, allowPredict)}
+          <span className={`rounded-full px-3 py-1 font-semibold ${statusStyles(match.status, locked, allowPredict, tbd)}`}>
+            {statusLabel(match.status, locked, allowPredict, tbd)}
           </span>
-          {allowPredict && locked && !isFinished && (
+          {allowPredict && locked && !isFinished && !tbd && (
             <span className="text-slate-400">Las predicciones cierran 2hs antes del partido</span>
           )}
           {canPredict && (
@@ -759,8 +770,9 @@ export default function ResultsTabs({
   // Agrupar por grupos (A, B, C, etc.)
   const matchesByGroup = useMemo(() => {
     const groups: Record<string, Match[]> = {}
-    
+
     matches.forEach((match) => {
+      if (!isGroupStage(match.stage)) return
       const groupLetter = TEAM_TO_GROUP[match.home_team] || 'Unknown'
       if (!groups[groupLetter]) {
         groups[groupLetter] = []

--- a/supabase/migrations/20260610_knockout_placeholder_matches.sql
+++ b/supabase/migrations/20260610_knockout_placeholder_matches.sql
@@ -1,0 +1,107 @@
+-- Agrega los 32 partidos "Por definir" de la fase eliminatoria del Mundial 2026:
+-- 16 Dieciseisavos de Final, 8 Octavos de Final, 4 Cuartos de Final, 2 Semifinales,
+-- 1 partido por el Tercer Puesto y 1 Final.
+--
+-- Estos partidos se cargan sin equipos asignados (home_team_id / away_team_id en NULL)
+-- y se identifican por home_team = away_team = 'Por definir'. El frontend los muestra
+-- en Resultados y Predicciones, pero no permite cargar pronósticos hasta que se
+-- conozcan los equipos de cada cruce.
+--
+-- Migración idempotente: cada bloque se inserta solo si todavía no existen partidos
+-- "Por definir" para esa instancia.
+
+BEGIN;
+
+-- 1) Dieciseisavos de Final (16 partidos)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.matches WHERE stage = 'Dieciseisavos de Final' AND home_team = 'Por definir'
+  ) THEN
+    INSERT INTO public.matches (home_team, away_team, match_date, stage, status) VALUES
+      ('Por definir', 'Por definir', '2026-06-28 17:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-06-28 21:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-06-29 00:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-06-29 17:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-06-29 21:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-06-30 00:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-06-30 17:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-06-30 21:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-01 00:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-01 17:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-01 21:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-02 00:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-02 17:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-02 21:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-03 00:00:00+00', 'Dieciseisavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-03 17:00:00+00', 'Dieciseisavos de Final', 'scheduled');
+  END IF;
+END $$;
+
+-- 2) Octavos de Final (8 partidos)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.matches WHERE stage = 'Octavos de Final' AND home_team = 'Por definir'
+  ) THEN
+    INSERT INTO public.matches (home_team, away_team, match_date, stage, status) VALUES
+      ('Por definir', 'Por definir', '2026-07-04 17:00:00+00', 'Octavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-04 21:00:00+00', 'Octavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-05 17:00:00+00', 'Octavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-05 21:00:00+00', 'Octavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-06 17:00:00+00', 'Octavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-06 21:00:00+00', 'Octavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-07 17:00:00+00', 'Octavos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-07 21:00:00+00', 'Octavos de Final', 'scheduled');
+  END IF;
+END $$;
+
+-- 3) Cuartos de Final (4 partidos)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.matches WHERE stage = 'Cuartos de Final' AND home_team = 'Por definir'
+  ) THEN
+    INSERT INTO public.matches (home_team, away_team, match_date, stage, status) VALUES
+      ('Por definir', 'Por definir', '2026-07-09 21:00:00+00', 'Cuartos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-10 17:00:00+00', 'Cuartos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-10 21:00:00+00', 'Cuartos de Final', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-11 21:00:00+00', 'Cuartos de Final', 'scheduled');
+  END IF;
+END $$;
+
+-- 4) Semifinales (2 partidos)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.matches WHERE stage = 'Semifinales' AND home_team = 'Por definir'
+  ) THEN
+    INSERT INTO public.matches (home_team, away_team, match_date, stage, status) VALUES
+      ('Por definir', 'Por definir', '2026-07-14 21:00:00+00', 'Semifinales', 'scheduled'),
+      ('Por definir', 'Por definir', '2026-07-15 21:00:00+00', 'Semifinales', 'scheduled');
+  END IF;
+END $$;
+
+-- 5) Partido por el Tercer Puesto (1 partido)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.matches WHERE stage = 'Tercer Puesto' AND home_team = 'Por definir'
+  ) THEN
+    INSERT INTO public.matches (home_team, away_team, match_date, stage, status) VALUES
+      ('Por definir', 'Por definir', '2026-07-18 21:00:00+00', 'Tercer Puesto', 'scheduled');
+  END IF;
+END $$;
+
+-- 6) Final (1 partido)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.matches WHERE stage = 'Final' AND home_team = 'Por definir'
+  ) THEN
+    INSERT INTO public.matches (home_team, away_team, match_date, stage, status) VALUES
+      ('Por definir', 'Por definir', '2026-07-19 19:00:00+00', 'Final', 'scheduled');
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
- Remove the old per-round advancement scoring system from the rules pages; all matches (group and knockout) now use the same 2pts winner
  + 1pt exact score rule, with the penalty-shootout winner counting for the 2pts and the regulation draw counting for the +1pt.
- Update max points totals (Grupos 216 / Eliminatoria 96 / Total 312) and rewrite the now-contradictory rules about knockout advancement and the third place match.
- Add migration inserting 32 "Por definir" placeholder knockout matches (16 Round of 32, 8 Round of 16, 4 quarterfinals, 2 semifinals, third place, final).
- Show these matches in Resultados and Predicciones, but mark them as "Por definir" and disable predictions until the bracket is set.
- Fix matchesByGroup to only include group-stage matches so the new knockout placeholders don't render under a bogus "Grupo Unknown".