### PR TITLE
Cambiar el cierre de pronósticos de 2 horas a 1 hora antes del partido

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -155,4 +155,4 @@ Las llaves de octavos/cuartos/semis/final dependen de las posiciones finales de 
 - [ ] Servicio backend en Railway: deploy OK, `/health` responde, variables configuradas
 - [ ] Servicio frontend en Railway: deploy OK, `NEXT_PUBLIC_API_URL` apunta al backend, login funciona
 - [ ] `/matches`, `/predictions`, "Tablas de Posiciones" cargan sin error 500
-- [ ] Probar que una predicción se puede guardar (>2hs antes del partido) y que se bloquea (<2hs antes), con el mensaje "Cerrado" en la UI
+- [ ] Probar que una predicción se puede guardar (>1h antes del partido) y que se bloquea (<1h antes), con el mensaje "Cerrado" en la UI

--- a/backend/src/controllers/predictionsController.js
+++ b/backend/src/controllers/predictionsController.js
@@ -43,9 +43,9 @@ export const upsertPrediction = async (req, res) => {
 
     const match = matchResult.rows[0];
     const kickoff = new Date(match.match_date).getTime();
-    const twoHoursBeforeMs = kickoff - 2 * 60 * 60 * 1000;
-    if (match.status !== 'scheduled' || Date.now() >= twoHoursBeforeMs) {
-      return res.status(400).json({ error: 'Las predicciones para este partido están cerradas (cierran 2 horas antes del inicio)' });
+    const oneHourBeforeMs = kickoff - 60 * 60 * 1000;
+    if (match.status !== 'scheduled' || Date.now() >= oneHourBeforeMs) {
+      return res.status(400).json({ error: 'Las predicciones para este partido están cerradas (cierran 1 hora antes del inicio)' });
     }
 
     // Upsert: insertar o actualizar si ya existe
@@ -82,9 +82,9 @@ export const deletePrediction = async (req, res) => {
 
     const match = matchResult.rows[0];
     const kickoff = new Date(match.match_date).getTime();
-    const twoHoursBeforeMs = kickoff - 2 * 60 * 60 * 1000;
-    if (match.status !== 'scheduled' || Date.now() >= twoHoursBeforeMs) {
-      return res.status(400).json({ error: 'Las predicciones para este partido están cerradas (cierran 2 horas antes del inicio)' });
+    const oneHourBeforeMs = kickoff - 60 * 60 * 1000;
+    if (match.status !== 'scheduled' || Date.now() >= oneHourBeforeMs) {
+      return res.status(400).json({ error: 'Las predicciones para este partido están cerradas (cierran 1 hora antes del inicio)' });
     }
 
     await query('DELETE FROM predictions WHERE user_id = $1 AND match_id = $2', [userId, matchId]);

--- a/frontend/app/dashboard/rules/page.tsx
+++ b/frontend/app/dashboard/rules/page.tsx
@@ -36,7 +36,7 @@ const importantRules = [
   },
   {
     title: 'Plazos de Pronósticos',
-    text: 'Las predicciones de cada partido se cierran 2 horas antes de su inicio. Pasado ese momento no se aceptan cambios.',
+    text: 'Las predicciones de cada partido se cierran 1 hora antes de su inicio. Pasado ese momento no se aceptan cambios.',
   },
   {
     title: 'Pronósticos Incompletos',

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -7,13 +7,6 @@
   --foreground: #171717;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
   color: var(--foreground);
   background: var(--background);

--- a/frontend/app/predictions/page.tsx
+++ b/frontend/app/predictions/page.tsx
@@ -75,7 +75,7 @@ export default function PredictionsPage() {
           userId={userId}
           showSecondaryTabs={false}
           title="Tus Predicciones"
-          description="Completá tus pronósticos para la fase de grupos y la fase eliminatoria. Las predicciones cierran 2 horas antes del inicio de cada partido. Los cruces de eliminatorias 'Por definir' se habilitan cuando se conocen los equipos."
+          description="Completá tus pronósticos para la fase de grupos y la fase eliminatoria. Las predicciones cierran 1 hora antes del inicio de cada partido. Los cruces de eliminatorias 'Por definir' se habilitan cuando se conocen los equipos."
         />
       </div>
     </div>

--- a/frontend/app/rules/page.tsx
+++ b/frontend/app/rules/page.tsx
@@ -36,7 +36,7 @@ const importantRules = [
   },
   {
     title: 'Plazos de Pronósticos',
-    text: 'Las predicciones de cada partido se cierran 2 horas antes de su inicio. Pasado ese momento no se aceptan cambios.',
+    text: 'Las predicciones de cada partido se cierran 1 hora antes de su inicio. Pasado ese momento no se aceptan cambios.',
   },
   {
     title: 'Pronósticos Incompletos',

--- a/frontend/components/matches/ResultsTabs.tsx
+++ b/frontend/components/matches/ResultsTabs.tsx
@@ -524,7 +524,7 @@ function ResultRow({
 
   const isFinished = match.status === 'finished'
   const tbd = isTBD(match)
-  const locked = Date.now() >= new Date(match.match_date).getTime() - 2 * 60 * 60 * 1000
+  const locked = Date.now() >= new Date(match.match_date).getTime() - 60 * 60 * 1000
   const canPredict = allowPredict && !isFinished && !locked && !tbd
   const isSaved = !!prediction
 
@@ -690,7 +690,7 @@ function ResultRow({
             {statusLabel(match.status, locked, allowPredict, tbd)}
           </span>
           {allowPredict && locked && !isFinished && !tbd && (
-            <span className="text-slate-400">Las predicciones cierran 2hs antes del partido</span>
+            <span className="text-slate-400">Las predicciones cierran 1h antes del partido</span>
           )}
           {canPredict && (
             isSaved ? (

--- a/frontend/components/matches/ResultsTabs.tsx
+++ b/frontend/components/matches/ResultsTabs.tsx
@@ -289,7 +289,7 @@ function ThirdsTable({ thirdTeams }: { thirdTeams: ThirdTeamRow[] }) {
                   key={`${team.code}-${team.group}`}
                   className={isPending ? 'bg-white' : isQualified ? 'bg-emerald-50' : 'bg-rose-50'}
                 >
-                  <td className="px-3 py-2 font-semibold text-slate-700">{index + 1}</td>
+                  <td className="px-3 py-2 font-semibold text-slate-900">{index + 1}</td>
                   <td className="px-3 py-2">
                     <div className="font-semibold text-slate-800 flex items-center gap-2">
                       <span className={`fi fi-${FLAG_CODES[team.code] || 'xx'} w-10 h-10`}></span>
@@ -391,7 +391,7 @@ function GroupTable({
         {teams.map((team, index) => (
           <div
             key={team.id}
-            className={`grid grid-cols-[2fr_repeat(7,1fr)_1.3fr] gap-2 px-3 py-2 text-xs text-slate-700 ${
+            className={`grid grid-cols-[2fr_repeat(7,1fr)_1.3fr] gap-2 px-3 py-2 text-xs text-slate-900 ${
               !started
                 ? 'bg-white'
                 : index === 0
@@ -647,7 +647,7 @@ function ResultRow({
             )
           ) : (
             <div className="flex flex-col items-center gap-1">
-              <div className="flex items-center gap-2 text-xs font-semibold text-slate-500">
+              <div className="flex items-center gap-2 text-xs font-semibold text-slate-900">
                 <span className="h-9 w-10 rounded-lg border border-slate-200 bg-slate-50 text-center leading-9">
                   {prediction ? prediction.predicted_home_score : match.home_score ?? '-'}
                 </span>
@@ -657,7 +657,7 @@ function ResultRow({
                 </span>
               </div>
               {prediction && (
-                <span className="text-[10px] text-slate-400">
+                <span className="text-[10px] text-slate-700">
                   Tu pronóstico{isFinished && prediction.points !== undefined ? ` · ${prediction.points} pts` : ''}
                 </span>
               )}


### PR DESCRIPTION
Actualiza el cálculo de bloqueo en frontend (ResultsTabs) y backend (predictionsController), junto con los textos de reglas, predicciones y el checklist de deploy.