### PR TITLE
Permitir pronosticar el ganador de penales en eliminatorias

### DIFF
--- a/backend/src/controllers/predictionsController.js
+++ b/backend/src/controllers/predictionsController.js
@@ -1,5 +1,10 @@
 import { query } from '../config/db.js';
 
+function isGroupStage(stage) {
+  const value = (stage || '').toLowerCase();
+  return value.includes('group') || value.includes('grupo');
+}
+
 // GET /api/predictions — predicciones del usuario autenticado
 export const getUserPredictions = async (req, res) => {
   try {
@@ -24,7 +29,7 @@ export const getUserPredictions = async (req, res) => {
 // POST /api/predictions — crear o actualizar predicción
 export const upsertPrediction = async (req, res) => {
   const userId = req.user.id;
-  const { match_id, predicted_home_score, predicted_away_score } = req.body;
+  const { match_id, predicted_home_score, predicted_away_score, predicted_penalty_winner } = req.body;
 
   try {
     if (!match_id || predicted_home_score === undefined || predicted_away_score === undefined) {
@@ -48,17 +53,28 @@ export const upsertPrediction = async (req, res) => {
       return res.status(400).json({ error: 'Las predicciones para este partido están cerradas (cierran 1 hora antes del inicio)' });
     }
 
+    // El ganador de penales solo se pronostica si el resultado predicho es
+    // empate en un partido de eliminatorias (en grupos no hay penales).
+    let penaltyWinner = null;
+    if (predicted_home_score === predicted_away_score && !isGroupStage(match.stage)) {
+      if (predicted_penalty_winner !== 'home' && predicted_penalty_winner !== 'away') {
+        return res.status(400).json({ error: 'Si predecís un empate en un partido de eliminatorias, elegí el ganador de la definición por penales' });
+      }
+      penaltyWinner = predicted_penalty_winner;
+    }
+
     // Upsert: insertar o actualizar si ya existe
     const result = await query(
-      `INSERT INTO predictions (user_id, match_id, predicted_home_score, predicted_away_score)
-       VALUES ($1, $2, $3, $4)
+      `INSERT INTO predictions (user_id, match_id, predicted_home_score, predicted_away_score, predicted_penalty_winner)
+       VALUES ($1, $2, $3, $4, $5)
        ON CONFLICT (user_id, match_id)
        DO UPDATE SET
          predicted_home_score = EXCLUDED.predicted_home_score,
          predicted_away_score = EXCLUDED.predicted_away_score,
+         predicted_penalty_winner = EXCLUDED.predicted_penalty_winner,
          updated_at = NOW()
        RETURNING *`,
-      [userId, match_id, predicted_home_score, predicted_away_score]
+      [userId, match_id, predicted_home_score, predicted_away_score, penaltyWinner]
     );
 
     res.status(201).json({ prediction: result.rows[0] });

--- a/frontend/app/dashboard/rules/page.tsx
+++ b/frontend/app/dashboard/rules/page.tsx
@@ -35,6 +35,10 @@ const importantRules = [
     text: 'En cualquier partido del Mundial, ya sea de fase de grupos o eliminatorias: 2 puntos por acertar el ganador, +1 punto extra si además acertás el resultado exacto. Si el partido termina empatado y se define por penales, el ganador de la definición por penales es el "ganador" del partido a los efectos de estos puntos, y el resultado exacto que vale el punto extra es el marcador del tiempo reglamentario (el empate, ej: 1-1), no el resultado de los penales.',
   },
   {
+    title: 'Pronóstico de Penales en Eliminatorias',
+    text: 'Si en un partido de eliminatorias predecís un empate (ej: 1-1), vas a tener que elegir además quién pensás que gana la definición por penales. Si el partido real también termina empatado en los 90\' y se define por penales, ese pronóstico cuenta como tu "ganador" a los efectos del puntaje (2 pts).',
+  },
+  {
     title: 'Plazos de Pronósticos',
     text: 'Las predicciones de cada partido se cierran 1 hora antes de su inicio. Pasado ese momento no se aceptan cambios.',
   },

--- a/frontend/app/rules/page.tsx
+++ b/frontend/app/rules/page.tsx
@@ -35,6 +35,10 @@ const importantRules = [
     text: 'En cualquier partido del Mundial, ya sea de fase de grupos o eliminatorias: 2 puntos por acertar el ganador, +1 punto extra si además acertás el resultado exacto. Si el partido termina empatado y se define por penales, el ganador de la definición por penales es el "ganador" del partido a los efectos de estos puntos, y el resultado exacto que vale el punto extra es el marcador del tiempo reglamentario (el empate, ej: 1-1), no el resultado de los penales.',
   },
   {
+    title: 'Pronóstico de Penales en Eliminatorias',
+    text: 'Si en un partido de eliminatorias predecís un empate (ej: 1-1), vas a tener que elegir además quién pensás que gana la definición por penales. Si el partido real también termina empatado en los 90\' y se define por penales, ese pronóstico cuenta como tu "ganador" a los efectos del puntaje (2 pts).',
+  },
+  {
     title: 'Plazos de Pronósticos',
     text: 'Las predicciones de cada partido se cierran 1 hora antes de su inicio. Pasado ese momento no se aceptan cambios.',
   },

--- a/frontend/components/matches/ResultsTabs.tsx
+++ b/frontend/components/matches/ResultsTabs.tsx
@@ -508,18 +508,20 @@ function ResultRow({
   match: Match
   userId: string
   allowPredict: boolean
-  prediction?: { predicted_home_score: number; predicted_away_score: number; points?: number } | null
-  onPredictionSaved?: (matchId: string, prediction: { predicted_home_score: number; predicted_away_score: number }) => void
+  prediction?: { predicted_home_score: number; predicted_away_score: number; predicted_penalty_winner?: 'home' | 'away' | null; points?: number } | null
+  onPredictionSaved?: (matchId: string, prediction: { predicted_home_score: number; predicted_away_score: number; predicted_penalty_winner?: 'home' | 'away' | null }) => void
   onPredictionDeleted?: (matchId: string) => void
 }) {
   const [homeScore, setHomeScore] = useState<number>(prediction?.predicted_home_score ?? 0)
   const [awayScore, setAwayScore] = useState<number>(prediction?.predicted_away_score ?? 0)
+  const [penaltyWinner, setPenaltyWinner] = useState<'home' | 'away' | null>(prediction?.predicted_penalty_winner ?? null)
   const [loading, setLoading] = useState(false)
   const [success, setSuccess] = useState(false)
 
   useEffect(() => {
     setHomeScore(prediction?.predicted_home_score ?? 0)
     setAwayScore(prediction?.predicted_away_score ?? 0)
+    setPenaltyWinner(prediction?.predicted_penalty_winner ?? null)
   }, [prediction])
 
   const isFinished = match.status === 'finished'
@@ -527,10 +529,18 @@ function ResultRow({
   const locked = Date.now() >= new Date(match.match_date).getTime() - 60 * 60 * 1000
   const canPredict = allowPredict && !isFinished && !locked && !tbd
   const isSaved = !!prediction
+  const showPenaltyPicker = homeScore === awayScore && !isGroupStage(match.stage)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!canPredict || isSaved) return
+
+    if (showPenaltyPicker && !penaltyWinner) {
+      alert('Predijiste un empate: elegí el ganador de la definición por penales')
+      return
+    }
+
+    const finalPenaltyWinner = showPenaltyPicker ? penaltyWinner : null
 
     setLoading(true)
     setSuccess(false)
@@ -547,6 +557,7 @@ function ResultRow({
           match_id: match.id,
           predicted_home_score: homeScore,
           predicted_away_score: awayScore,
+          predicted_penalty_winner: finalPenaltyWinner,
         }),
       })
 
@@ -556,7 +567,7 @@ function ResultRow({
       }
 
       setSuccess(true)
-      onPredictionSaved?.(match.id, { predicted_home_score: homeScore, predicted_away_score: awayScore })
+      onPredictionSaved?.(match.id, { predicted_home_score: homeScore, predicted_away_score: awayScore, predicted_penalty_winner: finalPenaltyWinner })
       setTimeout(() => setSuccess(false), 2500)
     } catch (error) {
       console.error('Error saving prediction:', error)
@@ -610,39 +621,73 @@ function ResultRow({
           </div>
         </div>
 
-        <div className="flex items-center justify-center gap-3">
+        <div className="flex flex-col items-center justify-center gap-2">
           {tbd ? (
             <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-500">
               Por definir
             </span>
           ) : canPredict ? (
             isSaved ? (
-              <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
-                <span className="h-9 w-10 rounded-lg border border-slate-200 bg-slate-50 text-center leading-9">
-                  {homeScore}
-                </span>
-                <span className="text-xs font-semibold text-slate-400">vs</span>
-                <span className="h-9 w-10 rounded-lg border border-slate-200 bg-slate-50 text-center leading-9">
-                  {awayScore}
-                </span>
+              <div className="flex flex-col items-center gap-1">
+                <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+                  <span className="h-9 w-10 rounded-lg border border-slate-200 bg-slate-50 text-center leading-9">
+                    {homeScore}
+                  </span>
+                  <span className="text-xs font-semibold text-slate-400">vs</span>
+                  <span className="h-9 w-10 rounded-lg border border-slate-200 bg-slate-50 text-center leading-9">
+                    {awayScore}
+                  </span>
+                </div>
+                {prediction?.predicted_penalty_winner && (
+                  <span className="text-[10px] text-slate-500">
+                    Penales: {prediction.predicted_penalty_winner === 'home' ? match.home_team : match.away_team}
+                  </span>
+                )}
               </div>
             ) : (
               <>
-                <input
-                  type="number"
-                  min="0"
-                  value={homeScore}
-                  onChange={(e) => setHomeScore(parseInt(e.target.value) || 0)}
-                  className="h-10 w-12 rounded-lg border border-slate-200 text-center text-sm font-semibold text-slate-900"
-                />
-                <span className="text-xs font-semibold text-slate-400">vs</span>
-                <input
-                  type="number"
-                  min="0"
-                  value={awayScore}
-                  onChange={(e) => setAwayScore(parseInt(e.target.value) || 0)}
-                  className="h-10 w-12 rounded-lg border border-slate-200 text-center text-sm font-semibold text-slate-900"
-                />
+                <div className="flex items-center gap-3">
+                  <input
+                    type="number"
+                    min="0"
+                    value={homeScore}
+                    onChange={(e) => setHomeScore(parseInt(e.target.value) || 0)}
+                    className="h-10 w-12 rounded-lg border border-slate-200 text-center text-sm font-semibold text-slate-900"
+                  />
+                  <span className="text-xs font-semibold text-slate-400">vs</span>
+                  <input
+                    type="number"
+                    min="0"
+                    value={awayScore}
+                    onChange={(e) => setAwayScore(parseInt(e.target.value) || 0)}
+                    className="h-10 w-12 rounded-lg border border-slate-200 text-center text-sm font-semibold text-slate-900"
+                  />
+                </div>
+                {showPenaltyPicker && (
+                  <div className="flex flex-col items-center gap-1">
+                    <span className="text-[10px] font-semibold text-slate-500">¿Quién gana en penales?</span>
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setPenaltyWinner('home')}
+                        className={`rounded-full px-3 py-1 text-[11px] font-semibold transition ${
+                          penaltyWinner === 'home' ? 'bg-sky-600 text-white' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+                        }`}
+                      >
+                        {match.home_team}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setPenaltyWinner('away')}
+                        className={`rounded-full px-3 py-1 text-[11px] font-semibold transition ${
+                          penaltyWinner === 'away' ? 'bg-sky-600 text-white' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+                        }`}
+                      >
+                        {match.away_team}
+                      </button>
+                    </div>
+                  </div>
+                )}
               </>
             )
           ) : (
@@ -658,7 +703,11 @@ function ResultRow({
               </div>
               {prediction && (
                 <span className="text-[10px] text-slate-700">
-                  Tu pronóstico{isFinished && prediction.points !== undefined ? ` · ${prediction.points} pts` : ''}
+                  Tu pronóstico
+                  {prediction.predicted_penalty_winner
+                    ? ` (penales: ${prediction.predicted_penalty_winner === 'home' ? match.home_team : match.away_team})`
+                    : ''}
+                  {isFinished && prediction.points !== undefined ? ` · ${prediction.points} pts` : ''}
                 </span>
               )}
             </div>
@@ -743,7 +792,7 @@ export default function ResultsTabs({
   const [activeSecondary, setActiveSecondary] = useState('Resultados')
   const [groups, setGroups] = useState<GroupRow[]>([])
   const [teams, setTeams] = useState<TeamRow[]>([])
-  const [predictions, setPredictions] = useState<Record<string, { predicted_home_score: number; predicted_away_score: number; points?: number }>>({})
+  const [predictions, setPredictions] = useState<Record<string, { predicted_home_score: number; predicted_away_score: number; predicted_penalty_winner?: 'home' | 'away' | null; points?: number }>>({})
   const [predictionsLoaded, setPredictionsLoaded] = useState(!allowPredict)
 
   const { groupStages, knockoutStages } = useMemo(() => {
@@ -805,11 +854,12 @@ export default function ResultsTabs({
 
         if (res.ok) {
           const data = await res.json()
-          const map: Record<string, { predicted_home_score: number; predicted_away_score: number; points?: number }> = {}
+          const map: Record<string, { predicted_home_score: number; predicted_away_score: number; predicted_penalty_winner?: 'home' | 'away' | null; points?: number }> = {}
           for (const p of data.predictions || []) {
             map[p.match_id] = {
               predicted_home_score: p.predicted_home_score,
               predicted_away_score: p.predicted_away_score,
+              predicted_penalty_winner: p.predicted_penalty_winner,
               points: p.points,
             }
           }
@@ -825,7 +875,7 @@ export default function ResultsTabs({
     loadPredictions()
   }, [allowPredict])
 
-  const handlePredictionSaved = (matchId: string, prediction: { predicted_home_score: number; predicted_away_score: number }) => {
+  const handlePredictionSaved = (matchId: string, prediction: { predicted_home_score: number; predicted_away_score: number; predicted_penalty_winner?: 'home' | 'away' | null }) => {
     setPredictions((prev) => ({ ...prev, [matchId]: prediction }))
   }
 

--- a/supabase/migrations/20260610_predicted_penalty_winner.sql
+++ b/supabase/migrations/20260610_predicted_penalty_winner.sql
@@ -1,0 +1,74 @@
+-- Permite pronosticar el ganador de la definición por penales cuando el
+-- usuario predice un empate en un partido de eliminatorias. Si el partido
+-- real también termina empatado en los 90' y se define por penales, ese
+-- pronóstico cuenta como "ganador" a los efectos del puntaje (2 pts).
+
+-- 1) Columna para el pronóstico del ganador de penales (solo aplica a
+--    pronósticos de empate en eliminatorias)
+ALTER TABLE predictions
+  ADD COLUMN IF NOT EXISTS predicted_penalty_winner TEXT;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'predictions_penalty_winner_valid'
+  ) THEN
+    ALTER TABLE predictions
+      ADD CONSTRAINT predictions_penalty_winner_valid CHECK (
+        predicted_penalty_winner IS NULL OR predicted_penalty_winner IN ('home', 'away')
+      );
+  END IF;
+END $$;
+
+-- 2) Recalcular puntos: si el pronóstico fue empate y el partido real también
+--    termina empatado en los 90' y se define por penales, usar
+--    predicted_penalty_winner como "ganador" pronosticado.
+CREATE OR REPLACE FUNCTION calculate_prediction_points()
+RETURNS TRIGGER AS $$
+DECLARE
+  pred RECORD;
+  actual_winner TEXT;
+  predicted_winner TEXT;
+BEGIN
+  IF NEW.status = 'finished' AND NEW.home_score IS NOT NULL AND NEW.away_score IS NOT NULL THEN
+    IF NEW.home_score > NEW.away_score THEN
+      actual_winner := 'home';
+    ELSIF NEW.home_score < NEW.away_score THEN
+      actual_winner := 'away';
+    ELSIF NEW.home_penalties IS NOT NULL AND NEW.away_penalties IS NOT NULL
+          AND NEW.home_penalties <> NEW.away_penalties THEN
+      actual_winner := CASE WHEN NEW.home_penalties > NEW.away_penalties THEN 'home' ELSE 'away' END;
+    ELSE
+      actual_winner := 'draw';
+    END IF;
+
+    FOR pred IN
+      SELECT * FROM predictions WHERE match_id = NEW.id
+    LOOP
+      predicted_winner := CASE
+        WHEN pred.predicted_home_score > pred.predicted_away_score THEN 'home'
+        WHEN pred.predicted_home_score < pred.predicted_away_score THEN 'away'
+        WHEN NEW.home_score = NEW.away_score AND pred.predicted_penalty_winner IS NOT NULL THEN pred.predicted_penalty_winner
+        ELSE 'draw'
+      END;
+
+      UPDATE predictions
+      SET points =
+        (CASE WHEN predicted_winner = actual_winner THEN 2 ELSE 0 END)
+        + (CASE
+             WHEN pred.predicted_home_score = NEW.home_score
+              AND pred.predicted_away_score = NEW.away_score THEN 1
+             ELSE 0
+           END),
+      updated_at = NOW()
+      WHERE id = pred.id;
+    END LOOP;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3) Recalcular puntos de partidos ya finalizados con la nueva fórmula
+UPDATE matches
+SET updated_at = NOW()
+WHERE status = 'finished' AND home_score IS NOT NULL AND away_score IS NOT NULL;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -53,6 +53,7 @@ CREATE TABLE IF NOT EXISTS predictions (
   match_id UUID REFERENCES matches(id) ON DELETE CASCADE NOT NULL,
   predicted_home_score INTEGER NOT NULL,
   predicted_away_score INTEGER NOT NULL,
+  predicted_penalty_winner TEXT CHECK (predicted_penalty_winner IS NULL OR predicted_penalty_winner IN ('home', 'away')),
   points INTEGER,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc', NOW()) NOT NULL,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc', NOW()) NOT NULL,
@@ -155,6 +156,9 @@ CREATE TRIGGER on_auth_user_created
 -- Reglas: 2 puntos por acertar el ganador (si el partido termina empatado y se
 -- define por penales, el ganador de la definición por penales es el ganador
 -- a estos efectos) + 1 punto extra si además se acierta el resultado exacto.
+-- Si el pronóstico fue empate y el partido real también termina empatado en
+-- los 90' y se define por penales, se usa predicted_penalty_winner como
+-- "ganador" pronosticado.
 CREATE OR REPLACE FUNCTION calculate_prediction_points()
 RETURNS TRIGGER AS $$
 DECLARE
@@ -182,6 +186,7 @@ BEGIN
       predicted_winner := CASE
         WHEN pred.predicted_home_score > pred.predicted_away_score THEN 'home'
         WHEN pred.predicted_home_score < pred.predicted_away_score THEN 'away'
+        WHEN NEW.home_score = NEW.away_score AND pred.predicted_penalty_winner IS NOT NULL THEN pred.predicted_penalty_winner
         ELSE 'draw'
       END;
 


### PR DESCRIPTION
Si el usuario predice un empate en un partido de eliminatorias, ahora debe elegir además quién gana la definición por penales. Ese campo solo se habilita cuando el resultado pronosticado es empate (igual que en el panel de admin, que ya solo pedía los penales reales si el resultado cargado era empate).

- DB: nueva columna predictions.predicted_penalty_winner ('home'/'away') y trigger calculate_prediction_points actualizado para usarla como "ganador" pronosticado cuando el partido real también termina empatado en los 90' y se define por penales.
- Backend: predictionsController valida y guarda el campo, exigiéndolo solo cuando corresponde.
- Frontend: ResultsTabs agrega el selector de ganador de penales y muestra el pronóstico guardado; reglas del juego actualizadas.